### PR TITLE
Merge series tags instead of overwriting when series exists

### DIFF
--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -28,6 +28,7 @@ export interface RadarrMovie {
   qualityProfileId: number;
   added: string;
   hasFile: boolean;
+  tags: number[];
 }
 
 class RadarrAPI extends ServarrBase<{ movieId: number }> {
@@ -106,7 +107,7 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
           minimumAvailability: options.minimumAvailability,
           tmdbId: options.tmdbId,
           year: options.year,
-          tags: options.tags,
+          tags: Array.from(new Set([...movie.tags, ...options.tags])),
           rootFolderPath: options.rootFolderPath,
           monitored: options.monitored,
           addOptions: {

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -169,7 +169,7 @@ class SonarrAPI extends ServarrBase<{
       // If the series already exists, we will simply just update it
       if (series.id) {
         series.monitored = options.monitored ?? series.monitored;
-        series.tags = options.tags ?? series.tags;
+        series.tags = options.tags ? Array.from(new Set([...series.tags, ...options.tags])) : series.tags;
         series.seasons = this.buildSeasonList(options.seasons, series.seasons);
 
         const newSeriesResponse = await this.axios.put<SonarrSeries>(


### PR DESCRIPTION
#### Description
Currently, a request coming in for a series that already exists in sonarr nukes the tags in sonarr for the series in favor of the tags coming from overseerr. This change merges the two lists of tags and deduplicates them before sending them to sonarr.
